### PR TITLE
unique check

### DIFF
--- a/src/includes/class-wp-vouched-verify-activator.php
+++ b/src/includes/class-wp-vouched-verify-activator.php
@@ -36,6 +36,7 @@ class Wp_Vouched_Verify_Activator {
                 $role->add_cap('place_orders', false);
             }
         }
+        add_role('verified', 'Verified Customer', array('read'=> true, 'place_orders'=>true));
 	}
 
 }

--- a/src/includes/class-wp-vouched-verify-activator.php
+++ b/src/includes/class-wp-vouched-verify-activator.php
@@ -30,7 +30,12 @@ class Wp_Vouched_Verify_Activator {
 	 * @since    1.0.0
 	 */
 	public static function activate() {
-
+        $roles = get_editable_roles();
+        foreach ($GLOBALS['wp_roles']->role_objects as $key => $role) {
+            if (isset($roles[$key]) && $role->has_cap('read')) {
+                $role->add_cap('place_orders', false);
+            }
+        }
 	}
 
 }

--- a/src/public/class-wp-vouched-verify-public.php
+++ b/src/public/class-wp-vouched-verify-public.php
@@ -157,7 +157,12 @@ class Wp_Vouched_Verify_Public
         if ($invite->{'status'} != 'completed') {
             $this
                 ->wp_wrapper
-                ->add_user_meta($user->ID, 'vouched-message', 'Vouched verification is not complete: Invite ' . $invite->{'status'}, false);
+                ->add_user_meta(
+                    $user->ID,
+                    'vouched-message',
+                    'Vouched verification is not complete: Invite ' . $invite->{'status'},
+                    false
+                );
 
             return;
         }
@@ -170,7 +175,12 @@ class Wp_Vouched_Verify_Public
         if ($job->{'status'} != 'completed') {
             $this
                 ->wp_wrapper
-                ->add_user_meta($user->ID, 'vouched-message', 'Vouched verification is not complete: Job ' . $job->{'status'}, false);
+                ->add_user_meta(
+                    $user->ID,
+                    'vouched-message',
+                    'Vouched verification is not complete: Job ' . $job->{'status'},
+                    false
+                );
 
             return;
         }
@@ -178,10 +188,21 @@ class Wp_Vouched_Verify_Public
         if ($job->{'reviewSuccess'} == false) {
             $this
                 ->wp_wrapper
-                ->add_user_meta($user->ID, 'vouched-message', 'Verification review did not pass. See Invite for details ' . $invite->{'url'}, false);
+                ->add_user_meta(
+                    $user->ID,
+                    'vouched-message',
+                    'Verification review did not pass. See Invite for details ' . $invite->{'url'},
+                    false
+                );
 
             return;
         }
+
+        $country = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_country');
+        $state = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_state');
+        $id = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_id');
+
+
 
     }
 }

--- a/src/public/class-wp-vouched-verify-public.php
+++ b/src/public/class-wp-vouched-verify-public.php
@@ -45,7 +45,11 @@ class Wp_Vouched_Verify_Public
 
     /** @var vouched_service */
     private $vouched_service;
-    private user_service_interface $user_service;
+
+    /**
+     * @var user_service_interface
+     */
+    private $user_service;
 
     /**
      * Initialize the class and set its properties.

--- a/src/public/class-wp-vouched-verify-public.php
+++ b/src/public/class-wp-vouched-verify-public.php
@@ -47,6 +47,7 @@ class Wp_Vouched_Verify_Public
 
     /** @var vouched_service */
     private $vouched_service;
+    private user_service_interface $user_service;
 
     /**
      * Initialize the class and set its properties.
@@ -55,17 +56,23 @@ class Wp_Vouched_Verify_Public
      * @param string $version The version of this plugin.
      * @param wp_wrapper_interface $wp_wrapper
      * @param vouched_service_interface $vouched_service
-     *
+     * @param user_service_interface $user_service
      * @since    1.0.0
      */
-    public function __construct(string $plugin_name, string $version, wp_wrapper_interface $wp_wrapper, vouched_service_interface $vouched_service)
-    {
+    public function __construct(
+        string $plugin_name,
+        string $version,
+        wp_wrapper_interface $wp_wrapper,
+        vouched_service_interface $vouched_service,
+        user_service_interface $user_service
+    ){
 
         $this->plugin_name = $plugin_name;
         $this->version = $version;
 
         $this->wp_wrapper = $wp_wrapper;
         $this->vouched_service = $vouched_service;
+        $this->user_service = $user_service;
     }
 
     /**
@@ -131,7 +138,7 @@ class Wp_Vouched_Verify_Public
 
         error_log("POST succeeded invite ID: " . $inviteID, 4);
 
-        $this->wp_wrapper->add_user_meta($user_id, 'inviteID', $inviteID, true);
+        $this->user_service->set_invite_id($user_id, $inviteID);
     }
 
     /**
@@ -146,7 +153,7 @@ class Wp_Vouched_Verify_Public
      */
     public function handle_wp_login(string $username, WP_User $user)
     {
-        $inviteId = $this->wp_wrapper->get_user_meta($user->ID, "inviteID");
+        $inviteId = $this->user_service->get_invite_id($user->ID);
 
         error_log("Retrived Invite " . $inviteId . " for user " . $user->ID, 4);
 
@@ -201,7 +208,6 @@ class Wp_Vouched_Verify_Public
         $country = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_country');
         $state = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_state');
         $id = $this->wp_wrapper->get_user_meta($user->ID, 'vouched_id');
-
 
 
     }

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -32,4 +32,31 @@ class user_service implements user_service_interface
     {
         return $this->wp_wrapper->get_user_meta($user_id, "inviteID");
     }
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_country(int $user_id): string
+    {
+        return $this->wp_wrapper->get_user_meta($user_id, "vouched_country");
+    }
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_state(int $user_id): string
+    {
+        return $this->wp_wrapper->get_user_meta($user_id, "vouched_state");
+    }
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_id_number(int $user_id): string
+    {
+        return $this->wp_wrapper->get_user_meta($user_id, "vouched_id");
+    }
 }

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -86,4 +86,31 @@ class user_service implements user_service_interface
     {
         $this->wp_wrapper->add_user_meta($user_id, 'vouched_id', $id, false);
     }
+
+    /**
+     * @param WP_User $user
+     * @param bool $verified
+     */
+    public function set_role_verified(WP_User $user, bool $verified)
+    {
+        if ($verified) {
+            $user->set_role('verified');
+        } else {
+            $user->set_role('customer');
+        }
+    }
+
+    /**
+     * @param int $user_id
+     * @param string $message
+     */
+    public function set_vouched_message(int $user_id, string $message)
+    {
+        $this->wp_wrapper->add_user_meta($user_id, 'vouched-message', $message, false);
+    }
+
+    public function unique_check(string $country, string $state, string $id): bool
+    {
+        // TODO: Implement unique_check() method.
+    }
 }

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -59,4 +59,31 @@ class user_service implements user_service_interface
     {
         return $this->wp_wrapper->get_user_meta($user_id, "vouched_id");
     }
+
+    /**
+     * @param int $user_id
+     * @param string $country
+     */
+    public function set_country(int $user_id, string $country)
+    {
+        $this->wp_wrapper->add_user_meta($user_id, 'vouched_country', $country, false);
+    }
+
+    /**
+     * @param int $user_id
+     * @param string $state
+     */
+    public function set_state(int $user_id, string $state)
+    {
+        $this->wp_wrapper->add_user_meta($user_id, 'vouched_state', $state, false);
+    }
+
+    /**
+     * @param int $user_id
+     * @param string $id
+     */
+    public function set_id_number(int $user_id, string $id)
+    {
+        $this->wp_wrapper->add_user_meta($user_id, 'vouched_id', $id, false);
+    }
 }

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -111,6 +111,33 @@ class user_service implements user_service_interface
 
     public function unique_check(string $country, string $state, string $id): bool
     {
-        // TODO: Implement unique_check() method.
+
+
+        $args = array(
+            'meta_query' => array(
+                'relation' => 'AND',
+                array(
+                    'key'     => 'vouched_country',
+                    'value'   => $country,
+                    'compare' => '='
+                ),
+                array(
+                    'key'     => 'vouched_state',
+                    'value'   => $state,
+                    'compare' => '='
+                ),
+                array(
+                    'key'     => 'vouched_id',
+                    'value'   => $id,
+                    'compare' => '='
+                )
+            )
+        );
+
+        $results = $this->wp_wrapper->query_users_with_meta_query($args);
+
+        $count = count($results);
+
+        return $count == 0;
     }
 }

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -5,7 +5,7 @@ class user_service implements user_service_interface
     /**
      * @var wp_wrapper_interface
      */
-    private wp_wrapper_interface $wp_wrapper;
+    private $wp_wrapper;
 
     /**
      * @param wp_wrapper_interface $wrapper

--- a/src/services/user_service.php
+++ b/src/services/user_service.php
@@ -1,0 +1,35 @@
+<?php
+
+class user_service implements user_service_interface
+{
+    /**
+     * @var wp_wrapper_interface
+     */
+    private wp_wrapper_interface $wp_wrapper;
+
+    /**
+     * @param wp_wrapper_interface $wrapper
+     */
+    public function __construct(wp_wrapper_interface $wrapper)
+    {
+        $this->wp_wrapper = $wrapper;
+    }
+
+    /**
+     * @param int $user_id
+     * @param string $inviteID
+     */
+    public function set_invite_id(int $user_id, string $inviteID)
+    {
+        $this->wp_wrapper->add_user_meta($user_id, 'inviteID', $inviteID, true);
+    }
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_invite_id(int $user_id): string
+    {
+        return $this->wp_wrapper->get_user_meta($user_id, "inviteID");
+    }
+}

--- a/src/services/user_service_interface.php
+++ b/src/services/user_service_interface.php
@@ -1,0 +1,34 @@
+<?php
+
+interface user_service_interface
+{
+    /**
+     * @param int $user_id
+     * @param string $inviteID
+     */
+    public function set_invite_id(int $user_id, string $inviteID);
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_invite_id(int $user_id) : string;
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_country(int $user_id) : string;
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_state(int $user_id) : string;
+
+    /**
+     * @param int $user_id
+     * @return string
+     */
+    public function get_id_number(int $user_id) : string;
+}

--- a/src/services/user_service_interface.php
+++ b/src/services/user_service_interface.php
@@ -12,25 +12,25 @@ interface user_service_interface
      * @param int $user_id
      * @return string
      */
-    public function get_invite_id(int $user_id) : string;
+    public function get_invite_id(int $user_id): string;
 
     /**
      * @param int $user_id
      * @return string
      */
-    public function get_country(int $user_id) : string;
+    public function get_country(int $user_id): string;
 
     /**
      * @param int $user_id
      * @return string
      */
-    public function get_state(int $user_id) : string;
+    public function get_state(int $user_id): string;
 
     /**
      * @param int $user_id
      * @return string
      */
-    public function get_id_number(int $user_id) : string;
+    public function get_id_number(int $user_id): string;
 
     /**
      * @param int $user_id
@@ -49,4 +49,24 @@ interface user_service_interface
      * @param string $id
      */
     public function set_id_number(int $user_id, string $id);
+
+    /**
+     * @param WP_User $user
+     * @param bool $verified
+     */
+    public function set_role_verified(WP_User $user, bool $verified);
+
+    /**
+     * @param int $user_id
+     * @param string $message
+     */
+    public function set_vouched_message(int $user_id, string $message);
+
+    /**
+     * @param string $country
+     * @param string $state
+     * @param string $id
+     * @return bool
+     */
+    public function unique_check(string $country, string $state, string $id): bool;
 }

--- a/src/services/user_service_interface.php
+++ b/src/services/user_service_interface.php
@@ -31,4 +31,22 @@ interface user_service_interface
      * @return string
      */
     public function get_id_number(int $user_id) : string;
+
+    /**
+     * @param int $user_id
+     * @param string $country
+     */
+    public function set_country(int $user_id, string $country);
+
+    /**
+     * @param int $user_id
+     * @param string $state
+     */
+    public function set_state(int $user_id, string $state);
+
+    /**
+     * @param int $user_id
+     * @param string $id
+     */
+    public function set_id_number(int $user_id, string $id);
 }

--- a/src/services/vouched_service.php
+++ b/src/services/vouched_service.php
@@ -84,11 +84,11 @@ class vouched_service implements vouched_service_interface {
 	/**
 	 * Send Invite request to Vouched using given email
 	 *
-	 * @return mixed
+	 * @return string
 	 * @throws Requests_Exception_HTTP
 	 * @throws Exception
 	 */
-	public function send_invite() {
+	public function send_invite(): string {
 		$body = array(
 			'email'   => $_POST['email'],
 			'contact' => "email"

--- a/src/services/vouched_service_interface.php
+++ b/src/services/vouched_service_interface.php
@@ -15,11 +15,11 @@ interface vouched_service_interface {
 	/**
 	 * Send Invite request to Vouched using given email
 	 *
-	 * @return mixed
+	 * @return string
 	 * @throws Requests_Exception_HTTP
 	 * @throws Exception
 	 */
-	public function send_invite();
+	public function send_invite(): string;
 
 	/**
 	 * @param string $jobId

--- a/src/services/wp_wrapper.php
+++ b/src/services/wp_wrapper.php
@@ -1,34 +1,51 @@
 <?php
 
-class wp_wrapper implements wp_wrapper_interface {
+class wp_wrapper implements wp_wrapper_interface
+{
 
-	public function get_option( string $string ) {
-		return get_option( $string );
-	}
+    public function get_option(string $string)
+    {
+        return get_option($string);
+    }
 
-	public function wp_remote_post( string $url, array $args ): array {
-		$response = wp_remote_post( $url, $args );
+    /**
+     * @throws Exception
+     */
+    public function wp_remote_post(string $url, array $args): array
+    {
+        $response = wp_remote_post($url, $args);
 
-		if ( is_wp_error( $response ) ) {
-			throw new Exception( $response->get_error_message() );
-		}
+        if (is_wp_error($response)) {
+            throw new Exception($response->get_error_message());
+        }
 
-		return $response;
-	}
+        return $response;
+    }
 
-	public function wp_remote_retrieve_response_code( array $response ): int {
-		return wp_remote_retrieve_response_code( $response );
-	}
+    public function wp_remote_retrieve_response_code(array $response): int
+    {
+        return wp_remote_retrieve_response_code($response);
+    }
 
-	public function add_user_meta( int $user_id, string $meta_key, $meta_value, bool $unique ): bool {
-		return add_user_meta( $user_id, $meta_key, $meta_value, $unique );
-	}
+    public function add_user_meta(int $user_id, string $meta_key, $meta_value, bool $unique): bool
+    {
+        return add_user_meta($user_id, $meta_key, $meta_value, $unique);
+    }
 
-	public function get_user_meta( int $user_id, string $meta_key ): string {
-		return get_user_meta( $user_id, $meta_key, true );
-	}
+    public function get_user_meta(int $user_id, string $meta_key): string
+    {
+        return get_user_meta($user_id, $meta_key, true);
+    }
 
-	public function wp_remote_get( string $url, array $args ): array {
-		return wp_remote_get( $url, $args );
-	}
+    public function wp_remote_get(string $url, array $args): array
+    {
+        return wp_remote_get($url, $args);
+    }
+
+    public function query_users_with_meta_query(array $query): array
+    {
+        $user_query = new WP_User_Query($query);
+
+        return $user_query->get_results();
+    }
 }

--- a/src/services/wp_wrapper_interface.php
+++ b/src/services/wp_wrapper_interface.php
@@ -13,4 +13,6 @@ interface wp_wrapper_interface
     public function add_user_meta(int $user_id, string $meta_key, $meta_value, bool $unique): bool;
 
     public function get_user_meta(int $user_id, string $meta_key): string;
+
+    public function query_users_with_meta_query(array $query): array;
 }

--- a/test/LoginTest.php
+++ b/test/LoginTest.php
@@ -8,6 +8,7 @@ require_once dirname(__FILE__) . '/../wordpress/wp-includes/class-wp-user.php';
 require_once dirname(__FILE__) . '/../src/public/class-wp-vouched-verify-public.php';
 require_once dirname(__FILE__) . '/../src/services/wp_wrapper_interface.php';
 require_once dirname(__FILE__) . '/../src/services/vouched_service_interface.php';
+require_once dirname(__FILE__) . '/../src/services/user_service_interface.php';
 
 class LoginTest extends TestCase
 {
@@ -25,7 +26,7 @@ class LoginTest extends TestCase
         $stub->expects($this->never())
             ->method('add_user_meta');
 
-        $userService = $this->getUserService();
+        $userService = $this->getUserService(true);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
@@ -44,7 +45,6 @@ class LoginTest extends TestCase
     public function testGivenInviteIsNotCompletedStoreMessage()
     {
         $stub = $this->getWpStub(false);
-        $stub->expects($this->once())->method('get_user_meta');
         $stub->expects($this->any())
             ->method('wp_remote_get')
             ->with('test.com/api/invites/?id=123');
@@ -54,7 +54,7 @@ class LoginTest extends TestCase
 
         $vouched = $this->getVouchedStub('accepted', 'active', false, '01/01/9999');
 
-        $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
+        $userService = $this->getUserService(false);
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
 
@@ -72,7 +72,6 @@ class LoginTest extends TestCase
     public function testGivenInviteIsCompletedWhenJobIsNotThenStoreMessage()
     {
         $stub = $this->getWpStub(false);
-        $stub->expects($this->once())->method('get_user_meta');
         $stub->expects($this->any())
             ->method('wp_remote_get')
             ->with('test.com/api/invites/?id=123');
@@ -82,7 +81,7 @@ class LoginTest extends TestCase
 
         $vouched = $this->getVouchedStub('completed', 'active', false, '01/01/9999');
 
-        $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
+        $userService = $this->getUserService(false);
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
 
@@ -109,7 +108,7 @@ class LoginTest extends TestCase
 
         $vouched = $this->getVouchedStub('completed', 'completed', false, '01/01/9999');
 
-        $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
+        $userService = $this->getUserService(true);
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
 

--- a/test/LoginTest.php
+++ b/test/LoginTest.php
@@ -16,46 +16,50 @@ class LoginTest extends TestCase
      */
     public function testGivenUserHasCompletedAndPassedVerificationAndIsUniqueWhenIdMatchesMetaThenSetHigherRole()
     {
-        $stub = $this->getWpStub();
-
-        $vouched = $this->getVouchedStub('completed', 'completed', true, '01/01/9999');
+        $vouched = $this
+            ->getVouchedStub('completed', 'completed', true, '01/01/9999');
         $vouched->expects($this->once())->method('get_invite')->with(123);
         $vouched->expects($this->once())->method('get_job')->with(5);
 
-        $stub->expects($this->never())
-            ->method('add_user_meta');
+        $user = $this->createStub(WP_User::class);
+
+        $user->user_email = 'john@test.com';
+        $user->ID = 1;
 
         $userService = $this->getUserService(true);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
 
-        $userService->expects($this->never())->method('unique_check')->with('US','IA','1234567890')->willReturn($this->returnValue(true));
+        $userService
+            ->expects($this->never())
+            ->method('unique_check')
+            ->with('US', 'IA', '1234567890')
+            ->willReturn(true);
 
         $userService->expects($this->never())->method('set_country');
         $userService->expects($this->never())->method('set_state');
         $userService->expects($this->never())->method('set_id_number');
 
-        $userService->expects($this->once())->method('set_role_verified')->with(true);
+        $userService->expects($this->once())->method('set_role_verified')->with($user, true);
 
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
-
-        $user = $this->createStub(WP_User::class);
-
-        $user->user_email = 'john@test.com';
-        $user->ID = 1;
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
 
+    /**
+     * @throws Requests_Exception_HTTP
+     */
     public function testGivenUserHasCompletedAndPassedVerificationWhenIdDoesNotMatchAndIsUniqueMetaThenStoreIdAndSetRole()
     {
-        $stub = $this->getWpStub();
-
-        $vouched = $this->getVouchedStub('completed', 'completed', true, '01/01/9999');
+        $vouched = $this
+            ->getVouchedStub('completed', 'completed', true, '01/01/9999');
         $vouched->expects($this->once())->method('get_invite')->with(123);
         $vouched->expects($this->once())->method('get_job')->with(5);
 
-        $stub->expects($this->never())
-            ->method('add_user_meta');
+        $user = $this->createStub(WP_User::class);
+
+        $user->user_email = 'john@test.com';
+        $user->ID = 1;
 
         $userService = $this->getUserService(false);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
@@ -63,34 +67,37 @@ class LoginTest extends TestCase
         $userService->expects($this->once())->method('get_state')->with(1);
         $userService->expects($this->once())->method('get_id_number')->with(1);
 
-        $userService->expects($this->once())->method('unique_check')->with('US','IA','1234567890')->willReturn($this->returnValue(true));
+        $userService
+            ->expects($this->once())
+            ->method('unique_check')
+            ->with('US', 'IA', '1234567890')
+            ->willReturn(true);
 
-        $userService->expects($this->once())->method('set_country')->with('US');
-        $userService->expects($this->once())->method('set_state')->with('IA');
-        $userService->expects($this->once())->method('set_id_number')->with('1234567890');
+        $userService->expects($this->once())->method('set_country')->with(1, 'US');
+        $userService->expects($this->once())->method('set_state')->with(1, 'IA');
+        $userService->expects($this->once())->method('set_id_number')->with(1, '1234567890');
 
-        $userService->expects($this->once())->method('set_role_verified')->with(false);
+        $userService->expects($this->once())->method('set_role_verified')->with($user, true);
 
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
-
-        $user = $this->createStub(WP_User::class);
-
-        $user->user_email = 'john@test.com';
-        $user->ID = 1;
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
 
+    /**
+     * @throws Requests_Exception_HTTP
+     */
     public function testGivenUserHasCompletedAndPassedVerificationWhenIdDoesNotMatchAndIsNotUniqueMetaThenStoreMessage()
     {
-        $stub = $this->getWpStub();
-
-        $vouched = $this->getVouchedStub('completed', 'completed', true, '01/01/9999');
+        $vouched = $this
+            ->getVouchedStub('completed', 'completed', true, '01/01/9999');
         $vouched->expects($this->once())->method('get_invite')->with(123);
         $vouched->expects($this->once())->method('get_job')->with(5);
 
-        $stub->expects($this->never())
-            ->method('add_user_meta');
+        $user = $this->createStub(WP_User::class);
+
+        $user->user_email = 'john@test.com';
+        $user->ID = 1;
 
         $userService = $this->getUserService(false);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
@@ -98,20 +105,20 @@ class LoginTest extends TestCase
         $userService->expects($this->once())->method('get_state')->with(1);
         $userService->expects($this->once())->method('get_id_number')->with(1);
 
-        $userService->expects($this->once())->method('unique_check')->with('US','IA','1234567890')->willReturn($this->returnValue(false));
+        $userService
+            ->expects($this->once())
+            ->method('unique_check')
+            ->with('US', 'IA', '1234567890')
+            ->willReturn(false);
 
-        $stub->expects($this->once())
-            ->method('add_user_meta')
-            ->with(1, 'vouched-message', 'Users verified ID is not unique', false);
+        $userService
+            ->expects($this->once())
+            ->method('set_vouched_message')
+            ->with(1, 'User 1(John) verified ID is not unique');
 
-        $userService->expects($this->once())->method('set_role_verified')->with(false);
+        $userService->expects($this->once())->method('set_role_verified')->with($user, false);
 
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
-
-        $user = $this->createStub(WP_User::class);
-
-        $user->user_email = 'john@test.com';
-        $user->ID = 1;
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
@@ -121,26 +128,24 @@ class LoginTest extends TestCase
      */
     public function testGivenInviteIsNotCompletedStoreMessage()
     {
-        $stub = $this->getWpStub();
-        $stub->expects($this->any())
-            ->method('wp_remote_get')
-            ->with('test.com/api/invites/?id=123');
-        $stub->expects($this->once())
-            ->method('add_user_meta')
-            ->with(1, 'vouched-message', 'Vouched verification is not complete: Invite accepted', false);
-
-        $vouched = $this->getVouchedStub('accepted', 'active', false, '01/01/9999');
-
-        $userService = $this->getUserService(false);
-
-        $userService->expects($this->once())->method('set_role_verified')->with(false);
-
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
+        $vouched = $this
+            ->getVouchedStub('accepted', 'active', false, '01/01/9999');
 
         $user = $this->createStub(WP_User::class);
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+
+        $userService = $this->getUserService(false);
+
+        $userService
+            ->expects($this->once())
+            ->method('set_vouched_message')
+            ->with(1, 'Vouched verification is not complete: Invite accepted');
+
+        $userService->expects($this->once())->method('set_role_verified')->with($user, false);
+
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
@@ -150,26 +155,24 @@ class LoginTest extends TestCase
      */
     public function testGivenInviteIsCompletedWhenJobIsNotThenStoreMessage()
     {
-        $stub = $this->getWpStub();
-        $stub->expects($this->any())
-            ->method('wp_remote_get')
-            ->with('test.com/api/invites/?id=123');
-        $stub->expects($this->once())
-            ->method('add_user_meta')
-            ->with(1, 'vouched-message', 'Vouched verification is not complete: Job active', false);
-
-        $vouched = $this->getVouchedStub('completed', 'active', false, '01/01/9999');
-
-        $userService = $this->getUserService(false);
-
-        $userService->expects($this->once())->method('set_role_verified')->with(false);
-
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
+        $vouched = $this
+            ->getVouchedStub('completed', 'active', false, '01/01/9999');
 
         $user = $this->createStub(WP_User::class);
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+
+        $userService = $this->getUserService(false);
+
+        $userService
+            ->expects($this->once())
+            ->method('set_vouched_message')
+            ->with(1, 'Vouched verification is not complete: Job active');
+
+        $userService->expects($this->once())->method('set_role_verified')->with($user, false);
+
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
@@ -179,26 +182,23 @@ class LoginTest extends TestCase
      */
     public function testGivenInviteIsCompletedAndJobIsCompletedWhenReviewSuccessIsFalseThenStoreMessage()
     {
-        $stub = $this->getWpStub();
-        $stub->expects($this->any())
-            ->method('wp_remote_get')
-            ->with('test.com/api/invites/?id=123');
-        $stub->expects($this->once())
-            ->method('add_user_meta')
-            ->with(1, 'vouched-message', 'Verification review did not pass. See Invite for details test.com/invite/123', false);
-
-        $vouched = $this->getVouchedStub('completed', 'completed', false, '01/01/9999');
+        $vouched = $this
+            ->getVouchedStub('completed', 'completed', false, '01/01/9999');
 
         $userService = $this->getUserService(true);
 
-        $userService->expects($this->once())->method('set_role_verified')->with(false);
-
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
-
         $user = $this->createStub(WP_User::class);
-
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+
+        $userService
+            ->expects($this->once())
+            ->method('set_vouched_message')
+            ->with(1, 'Verification review did not pass. See Invite for details test.com/invite/123');
+
+        $userService->expects($this->once())->method('set_role_verified')->with($user, false);
+
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 
         $pluginPublic->handle_wp_login('John', $user);
     }
@@ -220,7 +220,7 @@ class LoginTest extends TestCase
             ->willReturn((object)array(
                 'status' => $jobStatus,
                 'reviewSuccess' => $reviewSuccess,
-                'result' => (object) array(
+                'result' => (object)array(
                     'state' => 'IA',
                     'country' => 'US',
                     'id' => '1234567890',

--- a/test/RegisterTest.php
+++ b/test/RegisterTest.php
@@ -4,47 +4,37 @@ use PHPUnit\Framework\TestCase;
 
 require_once dirname(__FILE__) . '/../src/public/class-wp-vouched-verify-public.php';
 require_once dirname(__FILE__) . '/../src/services/wp_wrapper_interface.php';
+require_once dirname(__FILE__) . '/../src/services/vouched_service_interface.php';
+require_once dirname(__FILE__) . '/../src/services/user_service_interface.php';
 
 class RegisterTest extends TestCase
 {
+    /**
+     * @throws Requests_Exception_HTTP
+     */
     public function testUserRegisterShouldSaveInviteId()
     {
         $stub = $this->getWpStub();
 
-        $vouched = $this->getVouchedStub();
+        $vouched = $this->getMockBuilder(vouched_service_interface::class)->getMock();
 
-        $stub
-            ->expects($this->once())
-            ->method('add_user_meta')
-            ->with(
-                $this->equalTo(1),
-                $this->equalTo('inviteID'),
-                $this->equalTo('123'),
-                $this->equalTo(true)
-            );
+        $vouched->expects($this->once())->method('send_invite')->will($this->returnValue('123'));
 
         $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
+
+        $userService->expects($this->once())->method('set_invite_id')->with($this->equalTo(1), $this->equalTo('123'));
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
         $_POST['email'] = "test";
         $pluginPublic->handle_user_register(1);
     }
 
-    /**
-     * @return mixed
-     */
+
     private function getWpStub()
     {
         $stub = $this->getMockBuilder(wp_wrapper_interface::class)->getMock();
 
-        $stub->method('get_option')->willReturn(array('url' => 'test.com', 'api_key' => 'abcd1234'));
-        return $stub;
-    }
-
-    private function getVouchedStub() {
-        $stub = $this->getMockBuilder(vouched_service_interface::class)->getMock();
-        $stub->method('send_invite')
-            ->willReturn('123');
+        $stub->method('get_option')->willReturn(array('url' => 'test.com', 'api_key' => 'abc1234'));
         return $stub;
     }
 }

--- a/test/RegisterTest.php
+++ b/test/RegisterTest.php
@@ -14,8 +14,6 @@ class RegisterTest extends TestCase
      */
     public function testUserRegisterShouldSaveInviteId()
     {
-        $stub = $this->getWpStub();
-
         $vouched = $this->getMockBuilder(vouched_service_interface::class)->getMock();
 
         $vouched->expects($this->once())->method('send_invite')->will($this->returnValue('123'));
@@ -24,17 +22,8 @@ class RegisterTest extends TestCase
 
         $userService->expects($this->once())->method('set_invite_id')->with($this->equalTo(1), $this->equalTo('123'));
 
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
         $_POST['email'] = "test";
         $pluginPublic->handle_user_register(1);
-    }
-
-
-    private function getWpStub()
-    {
-        $stub = $this->getMockBuilder(wp_wrapper_interface::class)->getMock();
-
-        $stub->method('get_option')->willReturn(array('url' => 'test.com', 'api_key' => 'abc1234'));
-        return $stub;
     }
 }

--- a/test/RegisterTest.php
+++ b/test/RegisterTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 require_once dirname(__FILE__) . '/../src/public/class-wp-vouched-verify-public.php';
@@ -24,7 +23,9 @@ class RegisterTest extends TestCase
                 $this->equalTo(true)
             );
 
-        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched);
+        $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
+
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $stub, $vouched, $userService);
         $_POST['email'] = "test";
         $pluginPublic->handle_user_register(1);
     }

--- a/test/RegisterTest.php
+++ b/test/RegisterTest.php
@@ -20,7 +20,10 @@ class RegisterTest extends TestCase
 
         $userService = $this->getMockBuilder(user_service_interface::class)->getMock();
 
-        $userService->expects($this->once())->method('set_invite_id')->with($this->equalTo(1), $this->equalTo('123'));
+        $userService
+            ->expects($this->once())
+            ->method('set_invite_id')
+            ->with($this->equalTo(1), $this->equalTo('123'));
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
         $_POST['email'] = "test";

--- a/test/UserServiceTest.php
+++ b/test/UserServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__FILE__) . '/../vendor/autoload.php';
+require_once dirname(__FILE__) . '/../wordpress/wp-includes/class-wp-user.php';
+require_once dirname(__FILE__) . '/../src/services/wp_wrapper_interface.php';
+require_once dirname(__FILE__) . '/../src/services/user_service_interface.php';
+require_once dirname(__FILE__) . '/../src/services/user_service.php';
+
+class UserServiceTest extends TestCase
+{
+    public function testSetInviteIdShouldSaveIdToUserMeta()
+    {
+        $stub = $this->getWpStub(false);
+        $stub
+            ->expects($this->once())
+            ->method('add_user_meta')
+            ->with(
+                $this->equalTo(1),
+                $this->equalTo('inviteID'),
+                $this->equalTo('123'),
+                $this->equalTo(true)
+            );
+
+        $sut = new user_service($stub);
+
+        $sut->set_invite_id(1, '123');
+    }
+
+    public function testGetInviteIdShouldRetrieveIdFromUserMeta()
+    {
+        $stub = $this->getWpStub(false);
+        $stub->expects($this->once())->method('get_user_meta')->with(1, 'inviteID');
+
+        $sut = new user_service($stub);
+
+        $sut->get_invite_id(1);
+    }
+
+    /**
+     * @return mixed|MockObject|wp_wrapper_interface
+     */
+    public function getWpStub(bool $hasMeta)
+    {
+        $stub = $this->getMockBuilder(wp_wrapper_interface::class)->getMock();
+        $stub->method('get_option')->willReturn(array('url' => 'test.com', 'api_key' => 'abcd1234'));
+
+        $stub->method('get_user_meta')->with(1, 'inviteID')->willReturn('123');
+        if ($hasMeta) {
+            $stub->method('get_user_meta')->with(1, 'vouched_country')->willReturn('US');
+            $stub->method('get_user_meta')->with(1, 'vouched_state')->willReturn('IA');
+            $stub->method('get_user_meta')->with(1, 'vouched_id')->willReturn('1234567890');
+        }
+
+        return $stub;
+    }
+}

--- a/test/UserServiceTest.php
+++ b/test/UserServiceTest.php
@@ -39,6 +39,33 @@ class UserServiceTest extends TestCase
         $sut->get_invite_id(1);
     }
 
+    public function testGivenIdDoesNotExistInUserMetaThenReturnTrue()
+    {
+        $stub = $this->getWpStub(false);
+
+        $stub->expects($this->once())->method('query_users_with_meta_query')->willReturn(array());
+
+        $sut = new user_service($stub);
+
+        $actual = $sut->unique_check("US", "IA", '123456789');
+
+        $this->assertEquals(true, $actual);
+
+    }
+
+    public function testGivenIdExistsInUserMetaThenReturnFalse()
+    {
+        $stub = $this->getWpStub(false);
+
+        $stub->expects($this->once())->method('query_users_with_meta_query')->willReturn(array('stuff'));
+
+        $sut = new user_service($stub);
+
+        $actual = $sut->unique_check("US", "IA", '123456789');
+
+        $this->assertEquals(false, $actual);
+    }
+
     /**
      * @return mixed|MockObject|wp_wrapper_interface
      */


### PR DESCRIPTION
- Add new capability to be granted to Roles
- Add role for verified users
- Add results to get_job mock
- Get saved vouched meta data
- New service for user meta interactions
- Add new user service to app for login and register. incomplete
- Get user service mock
- Alter test to use services
- Implement vouched ID get methods for user service
- Add return type for send invite
- Methods for setting user's verified ID
- New test for uniqueness checking and setting the role
- Remove wp service from register test
- - Remove wp service - Fix set role tests - Add message function
- - remove use of wp wrapper - use user message function - check vouched results against meta - verify new results are unique - set role accordingly
- - set role - set message - stub for unique check (wip)
- finish method to get job object from vouched
- - method to run user meta queries - formatting
- tests to ensure unique check runs meta query and returns true if no results and false if results found
- Query user meta based on vouched ID fields. Return false if any are found.
- misc formatting #minor

Closes #15 
