### PR TITLE
Admins do not get verified

### DIFF
--- a/src/public/class-wp-vouched-verify-public.php
+++ b/src/public/class-wp-vouched-verify-public.php
@@ -155,6 +155,12 @@ class Wp_Vouched_Verify_Public
     {
         error_log("Verifying User \"" . $username . "\"", 4);
 
+        if(in_array('administrator', $user->roles)){
+            error_log($username . " is an admin. Skipping verification.",4);
+
+            return;
+        }
+
         $inviteId = $this->user_service->get_invite_id($user->ID);
 
         error_log("Retrived Invite " . $inviteId . " for user " . $user->ID, 4);

--- a/test/LoginTest.php
+++ b/test/LoginTest.php
@@ -230,9 +230,8 @@ class LoginTest extends TestCase
         $userService->expects($this->never())->method('get_invite_id');
 
         $userService
-            ->expects($this->once())
-            ->method('set_vouched_message')
-            ->with(1, 'Vouched verification skipped: admin');
+            ->expects($this->never())
+            ->method('set_vouched_message');
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 

--- a/test/LoginTest.php
+++ b/test/LoginTest.php
@@ -25,6 +25,7 @@ class LoginTest extends TestCase
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+        $user->roles = ['customer'];
 
         $userService = $this->getUserService(true);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
@@ -60,6 +61,7 @@ class LoginTest extends TestCase
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+        $user->roles = ['customer'];
 
         $userService = $this->getUserService(false);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
@@ -98,6 +100,7 @@ class LoginTest extends TestCase
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+        $user->roles = ['customer'];
 
         $userService = $this->getUserService(false);
         $userService->expects($this->once())->method('get_invite_id')->with(1);
@@ -135,6 +138,7 @@ class LoginTest extends TestCase
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+        $user->roles = ['customer'];
 
         $userService = $this->getUserService(false);
 
@@ -162,6 +166,7 @@ class LoginTest extends TestCase
 
         $user->user_email = 'john@test.com';
         $user->ID = 1;
+        $user->roles = ['customer'];
 
         $userService = $this->getUserService(false);
 
@@ -197,6 +202,37 @@ class LoginTest extends TestCase
             ->with(1, 'Verification review did not pass. See Invite for details test.com/invite/123');
 
         $userService->expects($this->once())->method('set_role_verified')->with($user, false);
+
+        $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
+
+        $pluginPublic->handle_wp_login('John', $user);
+    }
+
+    /**
+     * @throws Requests_Exception_HTTP
+     */
+    public function testGivenUserHasAdminRoleDoNotVerify()
+    {
+        $user = $this->createStub(WP_User::class);
+
+        $user->user_email = 'john@test.com';
+        $user->ID = 1;
+        $user->roles = ['administrator'];
+
+        $vouched = $this
+            ->getVouchedStub('completed', 'completed', false, '01/01/9999');
+
+        $vouched->expects($this->never())->method('get_invite');
+        $vouched->expects($this->never())->method('get_job');
+
+        $userService = $this->getUserService(false);
+
+        $userService->expects($this->never())->method('get_invite_id');
+
+        $userService
+            ->expects($this->once())
+            ->method('set_vouched_message')
+            ->with(1, 'Vouched verification skipped: admin');
 
         $pluginPublic = new Wp_Vouched_Verify_Public('Wp_Vouched_Verify', '1.0.0', $vouched, $userService);
 


### PR DESCRIPTION
- Test to ensure admins are not verified
- Test to ensure admins are not verified
- Check if user has the admin role then skip verification if so
Closes #45 