### PR TITLE
Resend Invite if no invite ID exisits for user

### DIFF
--- a/src/public/class-wp-vouched-verify-public.php
+++ b/src/public/class-wp-vouched-verify-public.php
@@ -134,7 +134,7 @@ class Wp_Vouched_Verify_Public
         error_log("User ID: " . $user_id, 4);
         error_log("User Email: " . $_POST['email'], 4);
 
-        $inviteID = $this->vouched_service->send_invite();
+        $inviteID = $this->vouched_service->send_invite($_POST['email']);
 
         error_log("POST succeeded invite ID: " . $inviteID, 4);
 
@@ -162,6 +162,19 @@ class Wp_Vouched_Verify_Public
         }
 
         $inviteId = $this->user_service->get_invite_id($user->ID);
+
+        if(!is_numeric($inviteId)) {
+            error_log("Invite ID not found for user " . $user->ID, 4);
+            $this->user_service->set_vouched_message($user->ID, 'Invite not found');
+
+            $inviteId = $this->vouched_service->send_invite($user->user_email);
+
+            $this->user_service->set_invite_id($user->ID, $inviteId);
+
+            $this->user_service->set_role_verified($user, false);
+
+            return;
+        }
 
         error_log("Retrived Invite " . $inviteId . " for user " . $user->ID, 4);
 

--- a/src/services/vouched_service.php
+++ b/src/services/vouched_service.php
@@ -88,9 +88,9 @@ class vouched_service implements vouched_service_interface {
 	 * @throws Requests_Exception_HTTP
 	 * @throws Exception
 	 */
-	public function send_invite(): string {
+	public function send_invite(string $email): string {
 		$body = array(
-			'email'   => $_POST['email'],
+			'email'   => $email,
 			'contact' => "email"
 		);
 

--- a/src/services/vouched_service_interface.php
+++ b/src/services/vouched_service_interface.php
@@ -19,7 +19,7 @@ interface vouched_service_interface {
 	 * @throws Requests_Exception_HTTP
 	 * @throws Exception
 	 */
-	public function send_invite(): string;
+	public function send_invite(string $email): string;
 
 	/**
 	 * @param string $jobId


### PR DESCRIPTION
- Test to verify invite sent if user does not have an invitation ID
- Require email to passed as a parameter to send invite method
- Send invite if user does not have an invite ID
Closes #49 